### PR TITLE
Update "modelchara_0 = exd/modelchara_0.exd" to the new offset in 3.56-hotfix0

### DIFF
--- a/FFXIV_TexTools/IO/ExdReader.cs
+++ b/FFXIV_TexTools/IO/ExdReader.cs
@@ -67,7 +67,7 @@ namespace FFXIV_TexTools.IO
         private void makeMinionsList(string offset)
         {
             byte[] minionsBytes = getDecompressedBytes(offset);
-            byte[] modelchara = getDecompressedBytes("04CDED00");
+            byte[] modelchara = getDecompressedBytes("05044080");
 
             using (BinaryReader br = new BinaryReader(new MemoryStream(minionsBytes)))
             {
@@ -156,7 +156,7 @@ namespace FFXIV_TexTools.IO
         private void makeMountsList(string offset)
         {
             byte[] mountBytes = getDecompressedBytes(offset);
-            byte[] modelchara = getDecompressedBytes("04CDED00");
+            byte[] modelchara = getDecompressedBytes("05044080");
 
             using (BinaryReader br = new BinaryReader(new MemoryStream(mountBytes)))
             {


### PR DESCRIPTION
We don't know if there are unpushed commits on your master,

simply changing these two values and recompiling gives us unrelated errors in
Form1.fillTreeView_Work(object sender, DoWorkEventArgs e)
where it tries to load minions/mounts, we had to disable it to get textools to work.

Disabling minion/mount loading seems to make the rest of it work, but we don't know enough about exd parsing (and specifically how textools does the parsing) to comment on why this is happening